### PR TITLE
Update requirements and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,156 @@
-venv/
-.venv/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+.venv*
+env/
+venv/
+venv*
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# packages
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.tar.gz
+*.zip
+*.log.*
+*.csar
+
+# default opera storage folder
 .opera/

--- a/cloud/aws/thumbnail-generator-with-vm/modules/ec2_vm/ec2_vm.yaml
+++ b/cloud/aws/thumbnail-generator-with-vm/modules/ec2_vm/ec2_vm.yaml
@@ -84,6 +84,9 @@ node_types:
                 default: { get_property: [ SELF, region ] }
             implementation: playbooks/delete.yaml
     requirements:
+      - host:
+          capability: tosca.capabilities.Compute
+          relationship: tosca.relationships.HostedOn
       - requires_prerequisites:
           capability: tosca.capabilities.Node
           relationship: tosca.relationships.DependsOn

--- a/cloud/aws/thumbnail-generator-with-vm/modules/vpc_subnet/vpc_subnet.yaml
+++ b/cloud/aws/thumbnail-generator-with-vm/modules/vpc_subnet/vpc_subnet.yaml
@@ -3,7 +3,7 @@ tosca_definitions_version: tosca_simple_yaml_1_3
 
 node_types:
   radon.nodes.aws.vpc_subnet:
-    derived_from: tosca.nodes.Compute
+    derived_from: tosca.nodes.SoftwareComponent
     attributes:
       vpc_id:
         type: string

--- a/cloud/gcp/thumbnail-generator/modules/function/function.yaml
+++ b/cloud/gcp/thumbnail-generator/modules/function/function.yaml
@@ -76,4 +76,11 @@ node_types:
               dependencies:
                 - playbooks/function
           delete: playbooks/delete.yaml
+    requirements:
+      - bucket_in:
+          capability: tosca.capabilities.Node
+          relationship: tosca.relationships.DependsOn
+      - bucket_function:
+          capability: tosca.capabilities.Node
+          relationship: tosca.relationships.DependsOn
 ...

--- a/cloud/gcp/thumbnail-generator/service.yaml
+++ b/cloud/gcp/thumbnail-generator/service.yaml
@@ -85,6 +85,5 @@ topology_template:
       requirements:
         - host: workstation
         - bucket_in: bucket_in
-        - bucket_out: bucket_out
         - bucket_function: bucket_function
 ...

--- a/csars/misc-tosca-types/modules/node_types/test/test.yaml
+++ b/csars/misc-tosca-types/modules/node_types/test/test.yaml
@@ -40,10 +40,7 @@ node_types:
       test_capability:
         type: daily_test.capabilities.test
     requirements:
-      - host1:
+      - host:
           capability: tosca.capabilities.Compute
           relationship: daily_test.relationships.test
-      - host2:
-          capability: tosca.capabilities.Compute
-          relationship: daily_test.relationships.interfaces
 ...

--- a/misc/concurrency/README.md
+++ b/misc/concurrency/README.md
@@ -14,62 +14,63 @@ We can run this example as follows:
 
 ```console
 (venv) misc/concurrency$ opera deploy -w 10 service.yaml
+[Worker_0]   Deploying my-workstation_0
 [Worker_0]   Deployment of my-workstation_0 complete
 [Worker_0]   Deploying hello-1_0
-[Worker_1]   Deploying hello-2_0
+[Worker_2]   Deploying hello-2_0
+[Worker_3]   Deploying hello-3_0
 [Worker_0]     Executing create on hello-1_0
-[Worker_2]   Deploying hello-3_0
 [Worker_4]   Deploying hello-4_0
-[Worker_3]   Deploying hello-8_0
-[Worker_6]   Deploying hello-9_0
-[Worker_1]     Executing create on hello-2_0
-[Worker_5]   Deploying hello-10_0
-[Worker_6]     Executing create on hello-9_0
+[Worker_5]   Deploying hello-8_0
+[Worker_3]     Executing create on hello-3_0
 [Worker_4]     Executing create on hello-4_0
-[Worker_7]   Deploying hello-14_0
-[Worker_2]     Executing create on hello-3_0
-[Worker_3]     Executing create on hello-8_0
-[Worker_5]     Executing create on hello-10_0
-[Worker_7]     Executing create on hello-14_0
-[Worker_6]     Executing start on hello-9_0
-[Worker_2]     Executing start on hello-3_0
-[Worker_7]     Executing start on hello-14_0
+[Worker_2]     Executing create on hello-2_0
+[Worker_1]   Deploying hello-9_0
+[Worker_7]   Deploying hello-10_0
+[Worker_5]     Executing create on hello-8_0
+[Worker_7]     Executing create on hello-10_0
+[Worker_1]     Executing create on hello-9_0
+[Worker_1]     Executing start on hello-9_0
 [Worker_4]     Executing start on hello-4_0
-[Worker_5]     Executing start on hello-10_0
-[Worker_7]   Deployment of hello-14_0 complete
-[Worker_6]   Deployment of hello-9_0 complete
-[Worker_2]   Deployment of hello-3_0 complete
-[Worker_8]   Deploying hello-12_0
-[Worker_8]     Executing create on hello-12_0
+[Worker_3]     Executing start on hello-3_0
+[Worker_7]     Executing start on hello-10_0
+[Worker_1]   Deployment of hello-9_0 complete
+[Worker_3]   Deployment of hello-3_0 complete
+[Worker_6]   Deploying hello-12_0
+[Worker_6]     Executing create on hello-12_0
 [Worker_4]   Deployment of hello-4_0 complete
-[Worker_7]   Deploying hello-13_0
-[Worker_7]     Executing create on hello-13_0
-[Worker_3]     Executing start on hello-8_0
-[Worker_1]     Executing start on hello-2_0
+[Worker_1]   Deploying hello-13_0
+[Worker_1]     Executing create on hello-13_0
+[Worker_5]     Executing start on hello-8_0
 [Worker_0]     Executing start on hello-1_0
-[Worker_8]     Executing start on hello-12_0
-[Worker_5]   Deployment of hello-10_0 complete
-[Worker_7]     Executing start on hello-13_0
-[Worker_8]   Deployment of hello-12_0 complete
-[Worker_3]   Deployment of hello-8_0 complete
-[Worker_7]   Deployment of hello-13_0 complete
-[Worker_1]   Deployment of hello-2_0 complete
+[Worker_2]     Executing start on hello-2_0
+[Worker_6]     Executing start on hello-12_0
+[Worker_7]   Deployment of hello-10_0 complete
+[Worker_1]     Executing start on hello-13_0
+[Worker_6]   Deployment of hello-12_0 complete
+[Worker_5]   Deployment of hello-8_0 complete
 [Worker_0]   Deployment of hello-1_0 complete
-[Worker_6]   Deploying hello-5_0
-[Worker_2]   Deploying hello-11_0
-[Worker_2]     Executing create on hello-11_0
-[Worker_6]     Executing create on hello-5_0
-[Worker_6]     Executing start on hello-5_0
-[Worker_2]     Executing start on hello-11_0
-[Worker_6]   Deployment of hello-5_0 complete
-[Worker_2]   Deployment of hello-11_0 complete
-[Worker_2]   Deploying hello-6_0
-[Worker_2]     Executing create on hello-6_0
-[Worker_2]     Executing start on hello-6_0
-[Worker_2]   Deployment of hello-6_0 complete
-[Worker_4]   Deploying hello-7_0
-[Worker_4]     Executing create on hello-7_0
-[Worker_4]     Executing start on hello-7_0
-[Worker_4]   Deployment of hello-7_0 complete
+[Worker_3]   Deploying hello-5_0
+[Worker_3]     Executing create on hello-5_0
+[Worker_8]   Deploying hello-11_0
+[Worker_8]     Executing create on hello-11_0
+[Worker_1]   Deployment of hello-13_0 complete
+[Worker_2]   Deployment of hello-2_0 complete
+[Worker_8]     Executing start on hello-11_0
+[Worker_3]     Executing start on hello-5_0
+[Worker_8]   Deployment of hello-11_0 complete
+[Worker_3]   Deployment of hello-5_0 complete
+[Worker_4]   Deploying hello-6_0
+[Worker_4]     Executing create on hello-6_0
+[Worker_4]     Executing start on hello-6_0
+[Worker_4]   Deployment of hello-6_0 complete
+[Worker_9]   Deploying hello-7_0
+[Worker_9]     Executing create on hello-7_0
+[Worker_9]     Executing start on hello-7_0
+[Worker_9]   Deployment of hello-7_0 complete
+[Worker_7]   Deploying hello-14_0
+[Worker_7]     Executing create on hello-14_0
+[Worker_7]     Executing start on hello-14_0
+[Worker_7]   Deployment of hello-14_0 complete
 ```
 

--- a/misc/concurrency/service.yaml
+++ b/misc/concurrency/service.yaml
@@ -139,7 +139,7 @@ topology_template:
         time: "1"
       requirements:
         - host: my-workstation
-        - dependency1:  hello-1
-        - dependency2:  hello-2
-        - dependency7:  hello-7
-        - dependency13:  hello-13
+        - dependency:  hello-1
+        - dependency:  hello-2
+        - dependency:  hello-7
+        - dependency:  hello-13

--- a/tosca/policy-triggers/service.yaml
+++ b/tosca/policy-triggers/service.yaml
@@ -38,6 +38,10 @@ node_types:
         type: radon.interfaces.scaling.ScaleDown
       autoscaling:
         type: radon.interfaces.scaling.AutoScale
+    requirements:
+      - host:
+          capability: tosca.capabilities.Compute
+          relationship: tosca.relationships.HostedOn
 
 interface_types:
   radon.interfaces.scaling.ScaleDown:


### PR DESCRIPTION
This PR will update TOSCA requirements within xOpera 
examples according to the latest changes for `opera` orchestrator. 