### PR TITLE
Update AWS thumbnail-generator-with-vm example

### DIFF
--- a/cloud/aws/thumbnail-generator-with-vm/modules/ec2_web_app/ec2_web_app.yaml
+++ b/cloud/aws/thumbnail-generator-with-vm/modules/ec2_web_app/ec2_web_app.yaml
@@ -12,7 +12,9 @@ node_types:
         type: string
       region:
         type: string
-      bucket_name:
+      bucket_in_name:
+        type: string
+      bucket_out_name:
         type: string
     interfaces:
       Standard:
@@ -29,9 +31,12 @@ node_types:
               region:
                 type: string
                 default: { get_property: [ SELF, region ] }
-              bucket_name:
+              bucket_in_name:
                 type: string
-                default: { get_property: [ SELF, bucket_name ] }
+                default: { get_property: [ SELF, bucket_in_name ] }
+              bucket_out_name:
+                type: string
+                default: { get_property: [ SELF, bucket_out_name ] }
             implementation:
               primary: playbooks/create.yaml
               dependencies:

--- a/cloud/aws/thumbnail-generator-with-vm/modules/ec2_web_app/playbooks/create.yaml
+++ b/cloud/aws/thumbnail-generator-with-vm/modules/ec2_web_app/playbooks/create.yaml
@@ -34,7 +34,8 @@
         state: started
         env:
           REGION_NAME: "{{ region }}"
-          BUCKET_NAME: "{{ bucket_name }}"
+          BUCKET_IN_NAME: "{{ bucket_in_name }}"
+          BUCKET_OUT_NAME: "{{ bucket_out_name }}"
       become: true
       become_method: sudo
 ...

--- a/cloud/aws/thumbnail-generator-with-vm/modules/ec2_web_app/web_app/index.js
+++ b/cloud/aws/thumbnail-generator-with-vm/modules/ec2_web_app/web_app/index.js
@@ -1,10 +1,20 @@
-const express = require('express');
-const app = express();
-const PORT = 80;
+const express = require('express')
+const path = require('path');
+const app = express()
+const multer = require('multer')
+const upload = multer()
 
 const AWS = require('aws-sdk');
+const PORT = 80;
 const REGION_NAME = process.env.REGION_NAME;
-const BUCKET_NAME = process.env.BUCKET_NAME;
+const BUCKET_IN_NAME = process.env.BUCKET_IN_NAME;
+const BUCKET_OUT_NAME = process.env.BUCKET_OUT_NAME;
+
+function encode(data) {
+    let buf = Buffer.from(data);
+    let base64 = buf.toString('base64');
+    return base64
+}
 
 // Set default route
 app.get('/', (req, res) => {
@@ -17,7 +27,7 @@ app.get('/', (req, res) => {
     async function getImageListFromBucket() {
         const data = await s3.listObjectsV2(
             {
-                Bucket: BUCKET_NAME
+                Bucket: BUCKET_OUT_NAME
             }
 
         ).promise();
@@ -28,7 +38,7 @@ app.get('/', (req, res) => {
                 data.Contents.forEach(async function (obj, index) {
                     const image = s3.getObject(
                         {
-                            Bucket: BUCKET_NAME,
+                            Bucket: BUCKET_OUT_NAME,
                             Key: obj.Key
                         }
 
@@ -43,28 +53,67 @@ app.get('/', (req, res) => {
         }
     }
 
-    // call async function that retrieves images and diplay them as HTML
+    // call async function that retrieves images and displays them as HTML
     getImageListFromBucket()
         .then((images) => {
-            let startHTML = "<html><body><h1>Resized images from '" + BUCKET_NAME + "' bucket</h1></body>";
+            let startHTML = "<html><body><h1>Thumbnail generator application (with AWS Lambda and S3 buckets)</h1>";
+            let imageUploadHTML = `<form method="POST" action="/upload" enctype="multipart/form-data">
+                <div>
+                    <label>Upload image to '${BUCKET_IN_NAME}' bucket:</label>
+                    <input type="file" name="new_image" />
+                    <input type="submit" name="upload_new_image_button" value="Upload" />
+                </div>
+            </form>
+            <h3>Resized images from '${BUCKET_OUT_NAME}' bucket:</h3>`
             let endHTML = "</body></html>";
             let imageHTML = "";
+
             images.forEach(function (image) {
                 imageHTML += "<img src='data:image/jpeg;base64," + encode(image.Body) + "'" + "/>\n";
             });
-            let html = startHTML + imageHTML + endHTML;
-            res.send(html)
-        }).catch((e) => {
-            res.send(e)
-        })
+            let html = startHTML + imageUploadHTML + imageHTML + endHTML;
 
-    function encode(data) {
-        let buf = Buffer.from(data);
-        let base64 = buf.toString('base64');
-        return base64
+            res.send(html);
+        }).catch((e) => {
+            res.send(e);
+        })
+});
+
+// route for uploading new images to S3 bucket
+app.post('/upload', upload.single('new_image'), (req, res) => {
+    // 'new_image' is the name of our file input field in the HTML form
+    // req.file contains information of uploaded file
+    // req.body contains information of text fields, if there were any
+
+    if (req.fileValidationError) {
+        return res.send(req.fileValidationError);
+    }
+    else if (!req.file) {
+        return res.send('<h3>Please select an image to upload!</h3><a href="/">Go back to main page</a>');
     }
 
-})
+    // Use S3 ManagedUpload class as it supports multipart uploads
+    var upload = new AWS.S3.ManagedUpload({
+        params: {
+            Bucket: BUCKET_IN_NAME,
+            Key: req.file.originalname,
+            Body: req.file.buffer
+        }
+    });
+
+    var promise = upload.promise();
+
+    promise.then(
+        function (data) {
+            console.log("Successfully uploaded new image.");
+        },
+        function (err) {
+            console.log(req.file);
+            console.log(`There was an error uploading image: ${err.message}`);
+        }
+    );
+    res.redirect('/');
+});
 
 // start the web server
 app.listen(PORT, () => {

--- a/cloud/aws/thumbnail-generator-with-vm/modules/ec2_web_app/web_app/package.json
+++ b/cloud/aws/thumbnail-generator-with-vm/modules/ec2_web_app/web_app/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "aws-sdk": "^2.885.0",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "multer": "^1.3.0"
   }
 }

--- a/cloud/aws/thumbnail-generator-with-vm/service.yaml
+++ b/cloud/aws/thumbnail-generator-with-vm/service.yaml
@@ -183,7 +183,8 @@ topology_template:
       properties:
         ssh_user: { get_input: ssh_user }
         region: { get_input: region }
-        bucket_name: { get_input: bucket_out_name }
+        bucket_in_name: { get_input: bucket_in_name }
+        bucket_out_name: { get_input: bucket_out_name }
       requirements:
         - host: ec2_vm
         - requires_prerequisites: prerequisites


### PR DESCRIPTION
This PR will update AWS thumbnail-generator-with-vm example. 
The most notable change is adding the option to upload images 
directly on the deployed web page instead of uploading them 
only to buckets. With this the application can be used only from
the web app and the user doesn't need to open AWS management
console ever.